### PR TITLE
Support MySQL encoding (utf8mb4)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,7 @@ runs:
             port: 3306
             username: root
             password: password
+            encoding: utf8mb4
         EOS
       shell: bash
       working-directory: ${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -106,7 +106,9 @@ runs:
           -e MYSQL_ROOT_PASSWORD=password \
           -e MYSQL_DATABASE=redmine_test \
           -p 3306:3306 \
-          -d ${{ inputs.database }}
+          -d ${{ inputs.database }} \
+          --character-set-server=utf8mb4 \
+          --collation-server=utf8mb4_unicode_ci
 
         cat <<EOS > config/database.yml
           test:


### PR DESCRIPTION
First of all, thanks for this nice action!

I tried to use this action on redmine_custom_fields_groups plugin's PR,
* https://github.com/gtt-project/redmine_custom_fields_groups/pull/28

but I encountered the following MySQL integration test failure.
* https://github.com/gtt-project/redmine_custom_fields_groups/actions/runs/9338225569/job/25701109039#step:7:41
  ```
  Error:
  LayoutTest#test_should_override_user_preference_setting_than_plugin_setting:
  ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect string value: '\xD0\xAD\xD1\x82\xD0\xB8...' for column 'title' at row 10
  ```

---

From some investigation, MySQL encoding (`utf8mb4`) setting seems to be necessary.
Redmine.org Wiki: https://www.redmine.org/projects/redmine/wiki/RedmineInstall#MySQL
> ### Step 2 - Create an empty database and accompanying user
> Redmine database user will be named redmine hereafter but it can be changed to anything else.
> #### MySQL
> ```sql
> CREATE DATABASE redmine CHARACTER SET utf8mb4;
> :
> ```

---

So, I added the encoding setting to `config/database.yml` and Docker arguments with referring the following official reference.
https://hub.docker.com/_/mysql
> ### Configuration without a cnf file
> Many configuration options can be passed as flags to `mysqld`. This will give you the flexibility to customize the container without needing a `cnf` file. For example, if you want to change the default encoding and collation for all tables to use UTF-8 (`utf8mb4`) just run the following:
> ```sh
> $ docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
> ```

---

I tested this PR fix on my plugin's fork repository's PR, so checking this PR is helpful. 🙇
* https://github.com/sanak/redmine_custom_fields_groups/pull/1
  * https://github.com/sanak/redmine_custom_fields_groups/actions/runs/9339121758