### PR TITLE
Support Redmine 4.2 and RedMica 2.0

### DIFF
--- a/.github/hello_world/db/migrate/20240518044930_create_hellos.rb
+++ b/.github/hello_world/db/migrate/20240518044930_create_hellos.rb
@@ -1,4 +1,4 @@
-class CreateHellos < ActiveRecord::Migration[6.1]
+class CreateHellos < ActiveRecord::Migration[5.2]
   def change
     create_table :hellos do |t|
       t.string :world

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,9 @@ jobs:
 
     - run: |
         bin/rails test test/unit/news_test.rb
-        bin/rails test test/system/my_page_test.rb
+        # Run system test only when Zeitwerk is enabled (Redmine >= 5.0 or RedMica >= 2.1)
+        if grep -q zeitwerk config/application.rb ; then
+          bin/rails test test/system/my_page_test.rb
+        fi
         bin/rails redmine:plugins:test
       working-directory: ${{ env.REDMINE_SRC }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,25 +22,32 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmine/redmine'
-            redmine-version: '5.1-stable'
+            redmine-version: '4.2-stable'
             redmine-database: 'sqlite3'
-            ruby-version: '3.2'
+            ruby-version: '2.7'
             expected-about-db-adapter: 'SQLite'
-            expected-about-redmine-version: '5\.1\.[0-9]\.stable'
+            expected-about-redmine-version: '4\.2\.[0-9]\+\.stable'
 
           - redmine-repository: 'redmine/redmine'
             redmine-version: '5.1-stable'
             redmine-database: 'mysql:8.1'
             ruby-version: '3.2'
             expected-about-db-adapter: 'Mysql2'
-            expected-about-redmine-version: '5\.1\.[0-9]\.stable'
+            expected-about-redmine-version: '5\.1\.[0-9]\+\.stable'
+
+          - redmine-repository: 'redmica/redmica'
+            redmine-version: 'stable-2.0'
+            redmine-database: 'postgres:10'
+            ruby-version: '2.7'
+            expected-about-db-adapter: 'PostgreSQL'
+            expected-about-redmine-version: '2\.0\.[0-9]\+\.stable'
 
           - redmine-repository: 'redmica/redmica'
             redmine-version: 'stable-2.4'
             redmine-database: 'postgres:14'
             ruby-version: '3.2'
             expected-about-db-adapter: 'PostgreSQL'
-            expected-about-redmine-version: '2\.4\.[0-9]\.stable'
+            expected-about-redmine-version: '2\.4\.[0-9]\+\.stable'
 
     steps:
     - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,17 @@ runs:
       shell: bash
       working-directory: ${{ inputs.path }}
 
+    - name: Adjust Gemfile
+      run: |
+        # Ref: https://github.com/agileware-jp/redmine-plugin-orb/pull/70
+        # https://www.redmine.org/issues/40802
+        if grep -q "require 'blankslate'" lib/redmine/views/builders/structure.rb
+        then
+          echo 'gem "blankslate"' >> Gemfile
+        fi
+      shell: bash
+      working-directory: ${{ inputs.path }}
+
     - name: Set up Ruby and install dependencies
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Fixes #6.

Changes proposed in this pull request:
- Add `gem "blankslate"` at the bottom of `Gemfile` before install dependencies.
  - [Patch #40802: Support builder 3.3.0 - Redmine](https://www.redmine.org/issues/40802)
  - https://github.com/agileware-jp/redmine-plugin-orb/pull/70
    - Apply only `blankslate` patch part, because `selenium-webdriver` patch part is a bit complex.
- Adjust test code/matrix to cover Redmine 4.2 and RedMica 2.0.
- Skip system test when Redmine 4.2 or RedMica 2.0.
  - Detect above condition whether Zeitwerk is disabled.