### PR TITLE
Separate setup script for each major version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - main
       - dev/**
     paths-ignore:
-      - '*.md'
+      - "*.md"
   pull_request:
 
 env:
@@ -21,74 +21,74 @@ jobs:
     strategy:
       matrix:
         include:
-          - redmine-repository: 'redmine/redmine'
-            redmine-version: '4.2-stable'
-            redmine-database: 'sqlite3'
-            ruby-version: '2.7'
-            expected-about-db-adapter: 'SQLite'
+          - redmine-repository: "redmine/redmine"
+            redmine-version: "4.2-stable"
+            redmine-database: "sqlite3"
+            ruby-version: "2.7"
+            expected-about-db-adapter: "SQLite"
             expected-about-redmine-version: '4\.2\.[0-9]\+\.stable'
 
-          - redmine-repository: 'redmine/redmine'
-            redmine-version: '5.1-stable'
-            redmine-database: 'mysql:8.1'
-            ruby-version: '3.2'
-            expected-about-db-adapter: 'Mysql2'
+          - redmine-repository: "redmine/redmine"
+            redmine-version: "5.1-stable"
+            redmine-database: "mysql:8.1"
+            ruby-version: "3.2"
+            expected-about-db-adapter: "Mysql2"
             expected-about-redmine-version: '5\.1\.[0-9]\+\.stable'
 
-          - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-2.0'
-            redmine-database: 'postgres:10'
-            ruby-version: '2.7'
-            expected-about-db-adapter: 'PostgreSQL'
+          - redmine-repository: "redmica/redmica"
+            redmine-version: "stable-2.0"
+            redmine-database: "postgres:10"
+            ruby-version: "2.7"
+            expected-about-db-adapter: "PostgreSQL"
             expected-about-redmine-version: '2\.0\.[0-9]\+\.stable'
 
-          - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-2.4'
-            redmine-database: 'postgres:14'
-            ruby-version: '3.2'
-            expected-about-db-adapter: 'PostgreSQL'
+          - redmine-repository: "redmica/redmica"
+            redmine-version: "stable-2.4"
+            redmine-database: "postgres:14"
+            ruby-version: "3.2"
+            expected-about-db-adapter: "PostgreSQL"
             expected-about-redmine-version: '2\.4\.[0-9]\+\.stable'
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: ./
-      with:
-        path: ${{ env.REDMINE_SRC }}
-        repository: ${{ matrix.redmine-repository }}
-        version: ${{ matrix.redmine-version }}
-        database: ${{ matrix.redmine-database }}
-        ruby-version: ${{ matrix.ruby-version }}
+      - uses: ./
+        with:
+          path: ${{ env.REDMINE_SRC }}
+          repository: ${{ matrix.redmine-repository }}
+          version: ${{ matrix.redmine-version }}
+          database: ${{ matrix.redmine-database }}
+          ruby-version: ${{ matrix.ruby-version }}
 
-    - name: Define Redmine version environment variables
-      run: ./scripts/set-version-envs.sh
-      env:
-        REDMINE_DIR: ${{ env.REDMINE_SRC }}
+      - name: Define Redmine version environment variables
+        run: ./scripts/set-version-envs.sh
+        env:
+          REDMINE_DIR: ${{ env.REDMINE_SRC }}
 
-    - name: Install a plugin for testing
-      run: |
-        cp -R ../.github/hello_world plugins/
-        bin/rails redmine:plugins:migrate
-      working-directory: ${{ env.REDMINE_SRC }}
+      - name: Install a plugin for testing
+        run: |
+          cp -R ../.github/hello_world plugins/
+          bin/rails redmine:plugins:migrate
+        working-directory: ${{ env.REDMINE_SRC }}
 
-    - name: Test Redmine environment
-      run: |
-        about=$(bin/rails r "require 'redmine/version'; puts Redmine::Info.environment")
-        echo "$about"
-        echo "$about" | grep "${{ matrix.expected-about-db-adapter }}"
-        echo "$about" | grep "${{ matrix.expected-about-redmine-version }}"
-        echo "$about" | grep "hello_world"
-      working-directory: ${{ env.REDMINE_SRC }}
+      - name: Test Redmine environment
+        run: |
+          about=$(bin/rails r "require 'redmine/version'; puts Redmine::Info.environment")
+          echo "$about"
+          echo "$about" | grep "${{ matrix.expected-about-db-adapter }}"
+          echo "$about" | grep "${{ matrix.expected-about-redmine-version }}"
+          echo "$about" | grep "hello_world"
+        working-directory: ${{ env.REDMINE_SRC }}
 
-    - name: Run unit test
-      run: bin/rails test test/unit/news_test.rb
-      working-directory: ${{ env.REDMINE_SRC }}
+      - name: Run unit test
+        run: bin/rails test test/unit/news_test.rb
+        working-directory: ${{ env.REDMINE_SRC }}
 
-    - name: Run system test if Redmine >= 5.0
-      if: ${{ env.REDMINE_VERSION_MAJOR >= 5 }}
-      run: bin/rails test test/system/my_page_test.rb
-      working-directory: ${{ env.REDMINE_SRC }}
+      - name: Run system test if Redmine >= 5.0
+        if: ${{ env.REDMINE_VERSION_MAJOR >= 5 }}
+        run: bin/rails test test/system/my_page_test.rb
+        working-directory: ${{ env.REDMINE_SRC }}
 
-    - name: Run plugin test
-      run: bin/rails redmine:plugins:test
-      working-directory: ${{ env.REDMINE_SRC }}
+      - name: Run plugin test
+        run: bin/rails redmine:plugins:test
+        working-directory: ${{ env.REDMINE_SRC }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,16 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Update major version tag
-      run: |
-        version=$(echo "${{ github.ref }}" | sed -r "s/^.*(v[0-9]).*$/\1/")
+      - name: Update major version tag
+        run: |
+          version=$(echo "${{ github.ref }}" | sed -r "s/^.*(v[0-9]).*$/\1/")
 
-        echo "Major Version: $version"
+          echo "Major Version: $version"
 
-        git config --local user.email "github-actions"
-        git config --local user.name "github-actions@github.com"
+          git config --local user.email "github-actions"
+          git config --local user.name "github-actions@github.com"
 
-        git tag -fa $version -m "Update $version tag"
-        git push -f origin $version
+          git tag -fa $version -m "Update $version tag"
+          git push -f origin $version

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This action installs Redmine and sets up an environment to run tests. It is prim
 
 See also [action.yml](./action.yml).
 
+## Supported Redmine version
+
+v4.2 or later
+
 ## Example
 
 ### Setting up [RedMica](https://github.com/redmica/redmica)

--- a/action.yml
+++ b/action.yml
@@ -78,69 +78,28 @@ runs:
         echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV
       shell: bash
 
-    - name: Set up PostgreSQL database connection for testing
+    - name: Set up PostgreSQL database
       if: ${{ startsWith(inputs.database, 'postgres:') }}
-      run: |
-        sudo apt-get install -y --no-install-recommends libpq-dev
-
-        docker run \
-          --name redmine-postgres \
-          -e POSTGRES_PASSWORD=postgres \
-          -p 5432:5432 \
-          -d ${{ inputs.database }}
-
-        cat <<EOS > config/database.yml
-          test:
-            adapter: postgresql
-            database: redmine_test
-            encoding: utf8
-            host: localhost
-            port: 5432
-            username: postgres
-            password: postgres
-        EOS
+      run: ./scripts/setup-db-postgresql.sh
       shell: bash
-      working-directory: ${{ inputs.path }}
+      env:
+        REDMINE_DIR: ${{ inputs.path }}
+        DATABASE: ${{ inputs.database }}
 
-    - name: Set up MySQL database connection for testing
+    - name: Set up MySQL database
       if: ${{ startsWith(inputs.database, 'mysql:') }}
-      run: |
-        sudo apt-get install -y --no-install-recommends default-mysql-client
-
-        docker run \
-          --name redmine-mysql \
-          -e MYSQL_ROOT_PASSWORD=password \
-          -e MYSQL_DATABASE=redmine_test \
-          -p 3306:3306 \
-          -d ${{ inputs.database }} \
-          --character-set-server=utf8mb4 \
-          --collation-server=utf8mb4_unicode_ci
-
-        cat <<EOS > config/database.yml
-          test:
-            adapter: mysql2
-            database: redmine_test
-            host: 127.0.0.1
-            port: 3306
-            username: root
-            password: password
-            encoding: utf8mb4
-        EOS
+      run: ./scripts/setup-db-mysql.sh
       shell: bash
-      working-directory: ${{ inputs.path }}
+      env:
+        REDMINE_DIR: ${{ inputs.path }}
+        DATABASE: ${{ inputs.database }}
 
-    - name: Set up SQLite3 database connection for testing
+    - name: Set up SQLite3 database
       if: ${{ inputs.database == 'sqlite3' }}
-      run: |
-        sudo apt-get install -y --no-install-recommends libsqlite3-dev
-
-        cat <<EOS > config/database.yml
-          test:
-            adapter: sqlite3
-            database: db/test.sqlite3
-        EOS
+      run: ./scripts/setup-db-sqlite3.sh
       shell: bash
-      working-directory: ${{ inputs.path }}
+      env:
+        REDMINE_DIR: ${{ inputs.path }}
 
       # https://www.redmine.org/issues/40802
     - name: Fix LoadError in Redmine 4.2

--- a/action.yml
+++ b/action.yml
@@ -7,24 +7,24 @@ branding:
 
 inputs:
   repository:
-    description: 'Redmine repository to setup. Default is redmine/redmine.'
+    description: "Redmine repository to setup. Default is redmine/redmine."
     required: true
-    default: 'redmine/redmine'
+    default: "redmine/redmine"
   version:
-    description: 'The branch, tag or commit to checkout. Default is master.'
+    description: "The branch, tag or commit to checkout. Default is master."
     required: true
-    default: 'master'
+    default: "master"
   database:
-    description: 'Database to use for testing. Possible values are sqlite3 or PostgreSQL and MySQL Docker official image tags (e.g. postgres:14, mysql:8.4.0). Default is sqlite3'
+    description: "Database to use for testing. Possible values are sqlite3 or PostgreSQL and MySQL Docker official image tags (e.g. postgres:14, mysql:8.4.0). Default is sqlite3"
     required: true
-    default: 'sqlite3'
+    default: "sqlite3"
   ruby-version:
     description: "Ruby version to use for testing. See ruby/setup-ruby's ruby-version input for available versions."
     required: true
   path:
-    description: 'Directory to setup Redmine. Default is the current directory.'
+    description: "Directory to setup Redmine. Default is the current directory."
     required: true
-    default: '.'
+    default: "."
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,16 @@ runs:
       env:
         REDMINE_DIR: ${{ inputs.path }}
 
+    - name: Check if the Redmine version is supported
+      run: |
+        if [ $redmine_version_number -lt $MINIUMUM_SUPPORTED_REDMINE_VERSION ]; then
+          echo "Redmine version $REDMINE_VERSION is not supported."
+          exit 1
+        fi
+      shell: bash
+      env:
+        MINIUMUM_SUPPORTED_REDMINE_VERSION: "420" # v4.2.0
+
     - name: Set up base environment
       run: |
         major_version_with_branch=$REDMINE_VERSION_MAJOR.$REDMINE_VERSION_MINOR.$REDMINE_VERSION_BRANCH

--- a/action.yml
+++ b/action.yml
@@ -51,32 +51,25 @@ runs:
       env:
         REDMINE_DIR: ${{ inputs.path }}
 
-    - name: Install dependencies
+    - name: Set up base environment
       run: |
-        sudo apt-get update; \
-        sudo apt-get install -y --no-install-recommends \
-          build-essential \
-          bzr git mercurial subversion cvs \
-          ghostscript \
-          gsfonts \
-          imagemagick libmagick++-dev \
-          libnss3-dev;
-      shell: bash
+        major_version_with_branch=$REDMINE_VERSION_MAJOR.$REDMINE_VERSION_MINOR.$REDMINE_VERSION_BRANCH
 
-    - name: Allow ImageMagick to read PDF files
-      run: |
-        sudo sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
-      shell: bash
+        case $major_version_with_branch in
+          5.1.devel)
+            setup_version="next";;
+          5.1*|5.0*|4.2*)
+            setup_version="$REDMINE_VERSION_MAJOR.$REDMINE_VERSION_MINOR";;
+          *)
+            setup_version="next";;
+        esac
 
-    - name: Set up Google Chrome for system tests
-      run: |
-        wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-        echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends google-chrome-stable
+        echo "Running scripts/setup-base-$setup_version.sh for Redmine $REDMINE_VERSION ..."
 
-        echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV
+        ./scripts/setup-base-$setup_version.sh
       shell: bash
+      env:
+        REDMINE_DIR: ${{ inputs.path }}
 
     - name: Set up PostgreSQL database
       if: ${{ startsWith(inputs.database, 'postgres:') }}
@@ -100,13 +93,6 @@ runs:
       shell: bash
       env:
         REDMINE_DIR: ${{ inputs.path }}
-
-      # https://www.redmine.org/issues/40802
-    - name: Fix LoadError in Redmine 4.2
-      if: ${{ env.REDMINE_VERSION_MAJOR < 5 }}
-      run: echo "gem 'builder', '~> 3.2.4'" >> Gemfile.local
-      shell: bash
-      working-directory: ${{ inputs.path }}
 
     - name: Set up Ruby and install dependencies
       uses: ruby/setup-ruby@v1

--- a/scripts/set-version-envs.sh
+++ b/scripts/set-version-envs.sh
@@ -9,9 +9,24 @@ version_minor=$(grep -oE 'MINOR *= *[0-9]+' $file | awk 'NR==1 {print $3}')
 version_tiny=$(grep -oE 'TINY *= *[0-9]+' $file | awk 'NR==1 {print $3}')
 version_branch=$(grep -oE 'BRANCH *= *'\''.+?' $file | awk -F"'" 'NR==1 {print $2}')
 
-echo "Redmine Version: $version_major.$version_minor.$version_tiny.$version_branch"
+redmine_version=$version_major.$version_minor.$version_tiny.$version_branch
+redmine_version_number=$version_major$version_minor$version_tiny
 
+# v5.1.3.stable -> 5.1.3.stable
+echo "REDMINE_VERSION=$redmine_version" >> $GITHUB_ENV
+
+# v5.1.3.stable -> 5
 echo "REDMINE_VERSION_MAJOR=$version_major" >> $GITHUB_ENV
+# v5.1.3.stable -> 1
 echo "REDMINE_VERSION_MINOR=$version_minor" >> $GITHUB_ENV
+# v5.1.3.stable -> 3
 echo "REDMINE_VERSION_TINY=$version_tiny" >> $GITHUB_ENV
+# v5.1.3.stable -> stable
 echo "REDMINE_VERSION_BRANCH=$version_branch" >> $GITHUB_ENV
+
+# v5.1.3.stable -> 513
+echo "REDMINE_VERSION_NUMNER=$redmine_version_number" >> $GITHUB_ENV
+
+# Output version information
+echo "Redmine Version: $redmine_version"
+echo "Redmine Version Number: $redmine_version_number"

--- a/scripts/setup-base-4.2.sh
+++ b/scripts/setup-base-4.2.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eu
+
+# Install dependencies
+sudo apt-get update; \
+sudo apt-get install -y --no-install-recommends \
+  build-essential \
+  bzr git mercurial subversion cvs \
+  ghostscript \
+  gsfonts \
+  imagemagick libmagick++-dev \
+  libnss3-dev;
+
+# Allow ImageMagick to read PDF files
+sudo sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
+
+# Set up Google Chrome for system tests
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends google-chrome-stable
+echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV
+
+# Fix LoadError cannot load such file -- builder
+# https://www.redmine.org/issues/40802
+echo "gem 'builder', '~> 3.2.4'" >> $REDMINE_DIR/Gemfile.local

--- a/scripts/setup-base-5.0.sh
+++ b/scripts/setup-base-5.0.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+# Install dependencies
+sudo apt-get update; \
+sudo apt-get install -y --no-install-recommends \
+  build-essential \
+  bzr git mercurial subversion cvs \
+  ghostscript \
+  gsfonts \
+  imagemagick libmagick++-dev \
+  libnss3-dev;
+
+# Allow ImageMagick to read PDF files
+sudo sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
+
+# Set up Google Chrome for system tests
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends google-chrome-stable
+echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV

--- a/scripts/setup-base-5.1.sh
+++ b/scripts/setup-base-5.1.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+# Install dependencies
+sudo apt-get update; \
+sudo apt-get install -y --no-install-recommends \
+  build-essential \
+  bzr git mercurial subversion cvs \
+  ghostscript \
+  gsfonts \
+  imagemagick libmagick++-dev \
+  libnss3-dev;
+
+# Allow ImageMagick to read PDF files
+sudo sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
+
+# Set up Google Chrome for system tests
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends google-chrome-stable
+echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV

--- a/scripts/setup-base-next.sh
+++ b/scripts/setup-base-next.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+# Install dependencies
+sudo apt-get update; \
+sudo apt-get install -y --no-install-recommends \
+  build-essential \
+  bzr git mercurial subversion cvs \
+  ghostscript \
+  gsfonts \
+  imagemagick libmagick++-dev \
+  libnss3-dev;
+
+# Allow ImageMagick to read PDF files
+sudo sed -ri 's/(rights)="none" (pattern="PDF")/\1="read" \2/' /etc/ImageMagick-6/policy.xml
+
+# Set up Google Chrome for system tests
+wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends google-chrome-stable
+echo GOOGLE_CHROME_OPTS_ARGS="headless,disable-gpu,no-sandbox,disable-dev-shm-usage" >> $GITHUB_ENV

--- a/scripts/setup-db-mysql.sh
+++ b/scripts/setup-db-mysql.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+sudo apt-get install -y --no-install-recommends default-mysql-client
+
+docker run \
+  --name redmine-mysql \
+  -e MYSQL_ROOT_PASSWORD=password \
+  -e MYSQL_DATABASE=redmine_test \
+  -p 3306:3306 \
+  -d $DATABASE \
+  --character-set-server=utf8mb4 \
+  --collation-server=utf8mb4_unicode_ci
+
+cd $REDMINE_DIR
+cat <<EOS > config/database.yml
+  test:
+    adapter: mysql2
+    database: redmine_test
+    host: 127.0.0.1
+    port: 3306
+    username: root
+    password: password
+    encoding: utf8mb4
+EOS

--- a/scripts/setup-db-postgresql.sh
+++ b/scripts/setup-db-postgresql.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+sudo apt-get install -y --no-install-recommends libpq-dev
+
+docker run \
+  --name redmine-postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -p 5432:5432 \
+  -d $DATABASE
+
+cd $REDMINE_DIR
+cat <<EOS > config/database.yml
+  test:
+    adapter: postgresql
+    database: redmine_test
+    encoding: utf8
+    host: localhost
+    port: 5432
+    username: postgres
+    password: postgres
+EOS

--- a/scripts/setup-db-sqlite3.sh
+++ b/scripts/setup-db-sqlite3.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+sudo apt-get install -y --no-install-recommends libsqlite3-dev
+
+cd $REDMINE_DIR
+cat <<EOS > config/database.yml
+  test:
+    adapter: sqlite3
+    database: db/test.sqlite3
+EOS


### PR DESCRIPTION
This pull request introduces the following changes:

* Improve code to separate setup script for each database type
* Separate the base environment setup script for each Redmine major version
* Support only [the version that the Redmine community supports](https://www.redmine.org/projects/redmine/wiki/Download)