### PR TITLE
Fix problems with minimum version checks

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,13 @@ runs:
 
     - name: Check if the Redmine version is supported
       run: |
-        if [ $redmine_version_number -lt $MINIUMUM_SUPPORTED_REDMINE_VERSION ]; then
+        if [ $REDMINE_MAJOR_VERSION_NUMNER -lt $MINIUMUM_SUPPORTED_REDMINE_VERSION ]; then
           echo "Redmine version $REDMINE_VERSION is not supported."
           exit 1
         fi
       shell: bash
       env:
-        MINIUMUM_SUPPORTED_REDMINE_VERSION: "420" # v4.2.0
+        MINIUMUM_SUPPORTED_REDMINE_VERSION: "402" # v4.2.x
 
     - name: Set up base environment
       run: |

--- a/scripts/set-version-envs.sh
+++ b/scripts/set-version-envs.sh
@@ -10,7 +10,7 @@ version_tiny=$(grep -oE 'TINY *= *[0-9]+' $file | awk 'NR==1 {print $3}')
 version_branch=$(grep -oE 'BRANCH *= *'\''.+?' $file | awk -F"'" 'NR==1 {print $2}')
 
 redmine_version=$version_major.$version_minor.$version_tiny.$version_branch
-redmine_version_number=$version_major$version_minor$version_tiny
+redmine_major_version_number=$version_major$(printf "%02d" $version_minor)
 
 # v5.1.3.stable -> 5.1.3.stable
 echo "REDMINE_VERSION=$redmine_version" >> $GITHUB_ENV
@@ -24,9 +24,9 @@ echo "REDMINE_VERSION_TINY=$version_tiny" >> $GITHUB_ENV
 # v5.1.3.stable -> stable
 echo "REDMINE_VERSION_BRANCH=$version_branch" >> $GITHUB_ENV
 
-# v5.1.3.stable -> 513
-echo "REDMINE_VERSION_NUMNER=$redmine_version_number" >> $GITHUB_ENV
+# v5.1.3.stable -> 501
+echo "REDMINE_MAJOR_VERSION_NUMNER=$redmine_major_version_number" >> $GITHUB_ENV
 
 # Output version information
 echo "Redmine Version: $redmine_version"
-echo "Redmine Version Number: $redmine_version_number"
+echo "Redmine Major Version Number: $redmine_major_version_number"


### PR DESCRIPTION
When the version is "v4.3.11", current minimum version checks does not work, because the version number of v4.3.11 will be `4311`, and the version number of v5.1.3 will be `513`.

This PR fixes the above problem.