### PR TITLE
Fixes #34 Redmine 5.1-stable branch error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,13 @@ jobs:
             expected-about-db-adapter: "Mysql2"
             expected-about-redmine-version: '6\.0\.[0-9]\+\.stable'
 
+          - redmine-repository: "redmine/redmine"
+            redmine-version: "5.1-stable"
+            redmine-database: "sqlite3"
+            ruby-version: "3.2"
+            expected-about-db-adapter: "SQLite"
+            expected-about-redmine-version: '5\.1\.[0-9]\+\.stable'
+
           - redmine-repository: "redmica/redmica"
             redmine-version: "stable-4.0"
             redmine-database: "postgres:14"

--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,13 @@ runs:
 
     - name: Check if the Redmine version is supported
       run: |
-        if [ $REDMINE_MAJOR_VERSION_NUMNER -lt $MINIUMUM_SUPPORTED_REDMINE_VERSION ]; then
+        if [ $REDMINE_MAJOR_VERSION_NUMBER -lt $MINIUMUM_SUPPORTED_REDMINE_VERSION ]; then
           echo "Redmine version $REDMINE_VERSION is not supported."
           exit 1
         fi
       shell: bash
       env:
-        MINIUMUM_SUPPORTED_REDMINE_VERSION: "510" # v5.1.0
+        MINIUMUM_SUPPORTED_REDMINE_VERSION: "501" # v5.1.0
 
     - name: Set up base environment
       run: $GITHUB_ACTION_PATH/scripts/setup-base.sh

--- a/scripts/set-version-envs.sh
+++ b/scripts/set-version-envs.sh
@@ -25,7 +25,7 @@ echo "REDMINE_VERSION_TINY=$version_tiny" >> $GITHUB_ENV
 echo "REDMINE_VERSION_BRANCH=$version_branch" >> $GITHUB_ENV
 
 # v5.1.3.stable -> 501
-echo "REDMINE_MAJOR_VERSION_NUMNER=$redmine_major_version_number" >> $GITHUB_ENV
+echo "REDMINE_MAJOR_VERSION_NUMBER=$redmine_major_version_number" >> $GITHUB_ENV
 
 # Output version information
 echo "Redmine Version: $redmine_version"


### PR DESCRIPTION
The issue #34 occurs because the value of `MINIUMUM_SUPPORTED_REDMINE_VERSION` is incorrect.

The original value “510” for `MINIMUM_SUPPORTED_REDMINE_VERSION` indicates version 5.10.x. The correct value is “501” (version 5.1.x).